### PR TITLE
Ensure paf-admin user created before granting privileges

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,11 @@ FROM mysql:latest
 
 # Initialize database, set privileges
 ADD init/data-playground.sql /docker-entrypoint-initdb.d/data.sql
-ADD init/privileges.sql /zdocker-entrypoint-initdb.d/privileges.sql
+ADD init/privileges.sh /docker-entrypoint-initdb.d/privileges.sh
+
+# Make sure the shell script is executable
+RUN chmod +x /docker-entrypoint-initdb.d/privileges.sh
+
 
 # Expose port 3306 to allow connections to the database
 EXPOSE 3306

--- a/init/privileges.sh
+++ b/init/privileges.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# Fail if PAF_ADMIN_PASSWORD is empty
+if [ -z "$PAF_ADMIN_PASSWORD" ]; then
+  echo "ERROR: Environment variable PAF_ADMIN_PASSWORD is not set."
+  exit 1
+fi
+
+echo "Creating user paf-admin with provided password..."
+
+mysql -u root -p"$MYSQL_ROOT_PASSWORD" <<-EOSQL
+CREATE USER IF NOT EXISTS 'paf-admin'@'%' IDENTIFIED BY '${PAF_ADMIN_PASSWORD}';
+GRANT ALL PRIVILEGES ON \`paf-admin\`.* TO 'paf-admin'@'%';
+FLUSH PRIVILEGES;
+EOSQL
+
+echo "User paf-admin created and granted privileges."

--- a/init/privileges.sql
+++ b/init/privileges.sql
@@ -1,2 +1,0 @@
-GRANT ALL on `paf-admin`.* TO `paf-admin`@`%`;
-FLUSH PRIVILEGES;


### PR DESCRIPTION
What’s fixed:
1. Ensured paf-admin user is created before applying privileges.
2. Switched from SQL to shell script to dynamically use `PAF_ADMIN_PASSWORD`.
3. Fixed incorrect init file path (`/zdocker-entrypoint-initdb.d` → `/docker-entrypoint-initdb.d`).

Why:
1. privileges.sql approach failed because user didn’t exist yet.
2. Shell script supports user creation(paf-admin) and password injection via environment variable.

Make sure to provide the `PAF_ADMIN_PASSWORD` environment variable when starting the container.